### PR TITLE
fixing case where playlistOld is undefined

### DIFF
--- a/src/angular-audio-player.js
+++ b/src/angular-audio-player.js
@@ -40,6 +40,7 @@ angular.module('angular-audio-player', ['helperFunctions'])
       this.tracks = playlist.length;
       // just exposing <audio> properties.
       this.volume = this._audioTag.volume;
+      this.muted = this._audioTag.muted;
       this.duration = this._audioTag.duration;
       this.formatDuration = '';
       this.currentTime = this._audioTag.currentTime;
@@ -107,6 +108,9 @@ angular.module('angular-audio-player', ['helperFunctions'])
       },
       pause: function () {
         this._audioTag.pause();
+      },
+      toggleMute: function () {
+        this.muted = this._audioTag.muted = !this._audioTag.muted;
       },
       next: function (autoplay) {
         var self = this;


### PR DESCRIPTION
I ran into this issue when I simply removed the playlist from the scope. Doing so caused the watch to fire with an undefined 'playlistOld'. I added a simple check against 'playlistOld' to make sure it was defined before dereferencing it. Let me know if you have any questions or comments.

Thanks!
Dave
