### PR TITLE
Change timeupdate throttle time

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -264,7 +264,7 @@ angular.module('mediaPlayer', ['mediaPlayer.helpers'])
             });
           }
         },
-        timeupdate: throttle(1000, false, function () {
+        timeupdate: throttle(250, false, function () {
           au.$apply(function (scope) {
             scope.currentTime = al.currentTime;
             scope.formatTime = scope.$formatTime(scope.currentTime);


### PR DESCRIPTION
For cases like subtitles/captions, we need timeupdate event to fire more often than once per 1000ms to display properly.
